### PR TITLE
en_US.UTF-8 locale set to default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu
+
 RUN apt-get update && \
 	apt-get install megatools -y
 RUN apt-get -y autoremove && \
@@ -6,4 +7,10 @@ RUN apt-get -y autoremove && \
 	rm -rf /var/lib/apt/lists/* && \
 	rm -rf /tmp/* && \
 	rm -rf /var/tmp/*
+
+RUN locale-gen en_US.UTF-8  
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8
+
 ENTRYPOINT ["megaput"]


### PR DESCRIPTION
If I try to upload (or even view) files/folders contains UTF-8 chars, I'm getting the garbage and upload fail. Now fixed.